### PR TITLE
New Device & Queue APIs + SocketIO Client + Expiration Timers

### DIFF
--- a/HardwareCheckout/__init__.py
+++ b/HardwareCheckout/__init__.py
@@ -5,6 +5,7 @@ from flask_user import UserManager
 from flask_socketio import SocketIO
 import os
 import json
+from datetime import datetime, timedelta
 from .config import db_path
 
 # init SQLAlchemy so we can use it later in our models
@@ -29,8 +30,7 @@ def create_app():
 
     from .timer import Timer
     global timer
-    timer = Timer('/timer')
-    app.register_blueprint(timer, url_prefix='/timer')
+    timer = Timer()
 
     from .models import User, Role
     UserManager.USER_ENABLE_EMAIL = False
@@ -58,7 +58,7 @@ def create_app():
     from .device import device as device_blueprint, restart_all_timers, DeviceNamespace
     app.register_blueprint(device_blueprint, url_prefix='/device')
     socketio.on_namespace(DeviceNamespace('/device'))
-    timer.add_timer(restart_all_timers, 2) # in case app server is restarted, all of these will need to be re-set
+    timer.add_timer('/device/timer', datetime.now() + timedelta(seconds=2))
     from .queue import queue as queue_blueprint, QueueNamespace
     app.register_blueprint(queue_blueprint, url_prefix='/queue')
     socketio.on_namespace(QueueNamespace('/queue'))

--- a/HardwareCheckout/__init__.py
+++ b/HardwareCheckout/__init__.py
@@ -59,8 +59,9 @@ def create_app():
     app.register_blueprint(main_blueprint)
     from .checkin import checkin as checkin_blueprint
     app.register_blueprint(checkin_blueprint)
-    from .device import device as device_blueprint
+    from .device import device as device_blueprint, restart_all_timers
     app.register_blueprint(device_blueprint, url_prefix='/device')
+    timer.add_timer(restart_all_timers, 2) # in case app server is restarted, all of these will need to be re-set
     from .queue import queue as queue_blueprint
     app.register_blueprint(queue_blueprint, url_prefix='/queue')
 

--- a/HardwareCheckout/__init__.py
+++ b/HardwareCheckout/__init__.py
@@ -31,6 +31,11 @@ def create_app():
             if current_user.is_authenticated:
                 join_room(str(current_user.id))
 
+    from .timer import Timer
+    global timer
+    timer = Timer('/timer')
+    app.register_blueprint(timer, url_prefix='/timer')
+
     from .models import User, Role
     UserManager.USER_ENABLE_EMAIL = False
     user_manager = UserManager(app, db, User)
@@ -54,5 +59,9 @@ def create_app():
     app.register_blueprint(main_blueprint)
     from .checkin import checkin as checkin_blueprint
     app.register_blueprint(checkin_blueprint)
+    from .device import device as device_blueprint
+    app.register_blueprint(device_blueprint, url_prefix='/device')
+    from .queue import queue as queue_blueprint
+    app.register_blueprint(queue_blueprint, url_prefix='/queue')
 
     return app

--- a/HardwareCheckout/device.py
+++ b/HardwareCheckout/device.py
@@ -107,12 +107,14 @@ def device_put(device, state, ssh=None, web=None, web_ro=None):
         return {'result', 'success'}
     if device.state in ('provision-failed', 'deprovision-failed'):
         return {'result': 'error', 'error': 'device disabled'}
-    if state not in ('is-provisioned', 'is-deprovisioned'):
+    if state not in ('is-provisioned', 'is-deprovisioned', 'client-connected'):
         return {'result': 'error', 'error': 'invalid state'}, 400
     if state == 'is-provisioned' and device.state == 'want-provision':
         device_ready(device)
     elif state == 'is-deprovisioned' and device.state == 'want-deprovision':
         provision_device(device)
+    elif state == 'client-connected' and device.state == 'in-queue':
+        device_in_use(device, True)
     elif device.state in ('disabled', 'want-deprovision'):
         if state != 'is-deprovisioned':
             send_device_state(device, 'want-deprovision')

--- a/HardwareCheckout/device.py
+++ b/HardwareCheckout/device.py
@@ -1,0 +1,98 @@
+from base64 import b64decode
+from datetime import datetime, timedelta
+
+from flask import abort, Blueprint, request, Response
+from functools import wraps
+from werkzeug.security import check_password_hash
+
+from . import db, socketio, timer
+from .models import DeviceQueue, UserQueue
+
+device = Blueprint('device', __name__)
+
+
+def auth_device(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if 'Authorization' not in request.headers or not request.headers['Authorization'].startswith('Basic '):
+            abort(Response(status=401, headers={'WWW-Authenticate': 'Basic realm="CarHackingVillage"'}))
+        name, password = b64decode(request.headers['Authorization'][6:]).decode('latin1').split(':', 1)
+        device = DeviceQueue.query.filter_by(name=name).one()
+        if not device or not check_password_hash(device.password, password):
+            abort(403)
+        return func(*args, **kwargs, device=device)
+    return wrapper
+
+
+def json_api(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        json = request.get_json()
+        if not json:
+            abort(415)
+        json.update(kwargs)
+        return func(*args, **json)
+    return wrapper
+
+
+@device.route('/state', methods=['PUT'])
+@auth_device
+@json_api
+def device_put(device, state, ssh=None, web=None, web_ro=None):
+    device.sshAddr = ssh
+    device.webUrl = web
+    device.roUrl = web_ro
+    db.session.add(device)
+    if state not in ('ready', 'in-use', 'provisioning'):
+        return {'result': 'error', 'error': 'invalid state'}, 400
+    if state == device.state:
+        db.session.commit()
+        return {'result': 'success'}
+    {
+        'ready': device_ready,
+        'in-use': device_in_use,
+        'provisioning': device_provisioning
+    }[state](device)
+    return {'result': 'success'}
+
+
+def device_ready(device):
+    device_id = device.id
+    if device.state == 'in-queue':
+        if datetime.now() < device.expiration:
+            delta = device.expiration - datetime.now()
+            timer.rm_timer(device.timer)
+            device.timer = timer.add_timer(lambda: device_ready(DeviceQueue.query.filter_by(id=device_id).one()), delta.total_seconds() + 1)
+            db.session.add(device)
+            db.session.commit()
+            return
+        else:
+            socketio.send({'message': 'device_lost', 'device': device.type}, json=True, room=str(device.owner))
+    next_user = UserQueue.query.filter_by(type=device.type).order_by(UserQueue.id).first()
+    if not next_user:
+        device.state = 'ready'
+        device.expiration = None
+        device.owner = None
+    else:
+        device.state = 'in-queue'
+        device.expiration = datetime.now() + timedelta(minutes=5)
+        device.owner = next_user.id
+        device.timer = timer.add_timer(lambda: device_ready(DeviceQueue.query.filter_by(id=device_id).one()), 301)
+        socketio.send({'message': 'device_available', 'device': device.type}, json=True, room=str(next_user.id))
+        db.session.delete(next_user)
+    db.session.add(device)
+    db.session.commit()
+
+
+def device_in_use(device):
+    device.state = 'in-use'
+    device.expiration = datetime.now() + timedelta(minutes=30)
+    timer.rm_timer(device.timer)
+    db.session.add(device)
+    db.session.commit()
+
+
+def device_provisioning(device):
+    device.state = 'provisioning'
+    db.session.add(device)
+    db.session.commit()

--- a/HardwareCheckout/device.py
+++ b/HardwareCheckout/device.py
@@ -12,6 +12,28 @@ from .models import DeviceQueue, UserQueue
 
 device = Blueprint('device', __name__)
 
+"""
+A brief guide to all the device states:
+  * ready  - device is ready to be used but not in queue
+  * in-queue - device is queued up to be used
+  * in-use - device is currently being used
+  * want-deprovision - server wants the device to deprovision itself
+  * is-deprovisioned - device has deprovisioned itself
+  * want-provision - server wants the device to provision itself
+  * is-provisioned - device has provisioned itself
+
+State transition guide:
+
+ready -> in-queue -> in-use -> want-deprovision -> is-deprovisioned -> want-provision -> is-provisioned -> ready
+             \                        /^
+              ------------------------
+
+Other states
+  * provision-failed - provision script failed (non-zero exit code)
+  * deprovision-failed - deprovision script failed (non-zero exit code)
+  * disabled - device disabled by admin
+"""
+
 
 def auth_device():
     if 'Authorization' not in request.headers or not request.headers['Authorization'].startswith('Basic '):
@@ -41,15 +63,21 @@ class DeviceNamespace(Namespace):
             return False
         session['device_id'] = device.id
         join_room('device:%i' % device.id)
+        if device.state in ('ready', 'in-queue', 'in-use', 'want-provision'):
+            send_device_state(device, 'want-provision')
+        elif device.state in ('disabled', 'want-deprovision'):
+            send_device_state(device, 'want-deprovision')
+        else:
+            send_device_state(device, 'error')
 
     def on_message(self, json):
         device_id = session['device_id']
-        device = DeviceQueue.query.filter_by(id=device_id)
-        if not device:
+        try:
+            device = DeviceQueue.query.filter_by(id=device_id).one()
+        except NoResultFound:
             disconnect()
             return False
-        else:
-            device_put.__wrapped__.__wrapped__(**json, device=device)
+        device_put.__wrapped__.__wrapped__(**json, device=device)
 
 
 def json_api(func):
@@ -71,65 +99,121 @@ def device_put(device, state, ssh=None, web=None, web_ro=None):
     device.webUrl = web
     device.roUrl = web_ro
     db.session.add(device)
-    if state not in ('ready', 'in-use', 'provisioning'):
-        return {'result': 'error', 'error': 'invalid state'}, 400
-    if state == device.state:
+    db.session.commit()
+    if state in ('provision-failed', 'deprovision-failed'):
+        device.state = state
+        db.session.add(device)
         db.session.commit()
-        socketio.send({'state': device.state}, json=True, namespace='/device', room='device:%i' % device.id)
-        return {'result': 'success'}
-    {
-        'ready': device_ready,
-        'in-use': device_in_use,
-        'provisioning': device_provisioning
-    }[state](device)
-    socketio.send({'state': device.state}, json=True, namespace='/device', room='device:%i' % device.id)
+        return {'result', 'success'}
+    if device.state in ('provision-failed', 'deprovision-failed'):
+        return {'result': 'error', 'error': 'device disabled'}
+    if state not in ('is-provisioned', 'is-deprovisioned'):
+        return {'result': 'error', 'error': 'invalid state'}, 400
+    if state == 'is-provisioned' and device.state == 'want-provision':
+        device_ready(device)
+    elif state == 'is-deprovisioned' and device.state == 'want-deprovision':
+        provision_device(device)
+    elif device.state in ('disabled', 'want-deprovision'):
+        if state != 'is-deprovisioned':
+            send_device_state(device, 'want-deprovision')
+        else:
+            return {'result': 'success'}
+    elif state != 'is-provisioned':
+        send_device_state(device, 'want-provision')
     return {'result': 'success'}
 
 
+def state_callback(device_id):
+    def callback():
+        device = DeviceQueue.query.filter_by(id=device_id).one()
+        {
+            'ready': device_ready,
+            'in-queue': device_in_queue,
+            'in-use': device_in_use
+        }[device.state](device)
+    return callback
+
+
 def device_ready(device):
-    device_id = device.id
-    if device.state == 'in-queue':
-        if datetime.now() < device.expiration:
-            delta = device.expiration - datetime.now()
-            timer.rm_timer(device.timer)
-            device.timer = timer.add_timer(lambda: device_ready(DeviceQueue.query.filter_by(id=device_id).one()), delta.total_seconds() + 1)
-            db.session.add(device)
-            db.session.commit()
-            return
-        else:
-            socketio.send({'message': 'device_lost', 'device': device.type}, json=True, room='user:%i' % device.owner, namespace='/queue')
-    next_user = UserQueue.query.filter_by(type=device.type).order_by(UserQueue.id).first()
-    if not next_user:
-        device.state = 'ready'
-        device.expiration = None
-        device.owner = None
-    else:
-        device.state = 'in-queue'
-        device.expiration = datetime.now() + timedelta(minutes=5)
-        device.owner = next_user.id
-        device.timer = timer.add_timer(lambda: device_ready(DeviceQueue.query.filter_by(id=device_id).one()), 301)
-        socketio.send({'message': 'device_available', 'device': device.type}, json=True, room='user:%i' % device.owner, namespace='/queue')
-        db.session.delete(next_user)
+    device.state = 'ready'
+    device.expiration = None
+    device.owner = None
     db.session.add(device)
     db.session.commit()
+    next_user = UserQueue.query.filter_by(type=device.type).order_by(UserQueue.id).first()
+    if next_user:
+        db.session.delete(next_user)
+        return device_in_queue(device, next_user)
 
 
-def device_in_use(device):
+def device_in_queue(device, next_user=None):
+    device.state = 'in-queue'
+    if next_user is not None:
+        device.owner = next_user.id
+        device.expiration = datetime.now() + timedelta(minutes=5)
+        send_message_to_owner(device, 'device_available')
+    db.session.add(device)
+    db.session.commit()
+    if datetime.now() < device.expiration:
+        delta = device.expiration - datetime.now()
+        timer.rm_timer(device.timer)
+        device.timer = timer.add_timer(state_callback(device.id), delta.total_seconds() + 1)
+        db.session.add(device)
+        db.session.commit()
+        return
+    else:
+        send_message_to_owner(device, 'device_lost')
+        return deprovision_device(device)
+
+
+def device_in_use(device, reset_timer=False):
     device.state = 'in-use'
-    device.expiration = datetime.now() + timedelta(minutes=30)
+    if reset_timer:
+        device.expiration = datetime.now() + timedelta(minutes=30)
+    if datetime.now() < device.expiration:
+        delta = device.expiration - datetime.now()
+        timer.rm_timer(device.timer)
+        device.timer = timer.add_timer(state_callback(device.id), delta.total_seconds() + 1)
+        db.session.add(device)
+        db.session.commit()
+        return
+    else:
+        send_message_to_owner(device, 'device_reclaimed')
+        return deprovision_device(device)
+
+
+def deprovision_device(device):
+    device.state = 'want-deprovision'
+    device.expiration = None
     timer.rm_timer(device.timer)
     db.session.add(device)
     db.session.commit()
+    send_device_state(device, 'want-deprovision')
 
 
-def device_provisioning(device):
-    device.state = 'provisioning'
+def provision_device(device):
+    device.state = 'want-provision'
     device.expiration = None
+    timer.rm_timer(device.timer)
     db.session.add(device)
     db.session.commit()
+    send_device_state(device, 'want-provision')
+
+
+def send_device_state(device, state, **kwargs):
+    kwargs['state'] = state
+    return socketio.send(kwargs, json=True, namespace='/device', room='device:%i' % device.id)
+
+
+def send_message_to_owner(device, message):
+    return socketio.send({'message': message, 'device': device.type}, json=True, namespace='/queue', room='user:%i' % device.owner)
 
 
 def restart_all_timers():
     for device in DeviceQueue.query:
-        if device.state in ('ready', 'in-queue'):
-            device_ready(device)
+        if device.state in ('ready', 'in-queue', 'in-use'):
+            {
+                'ready': device_ready,
+                'in-queue': device_in_queue,
+                'in-use': device_in_use
+            }[device.state](device)

--- a/HardwareCheckout/device.py
+++ b/HardwareCheckout/device.py
@@ -172,6 +172,7 @@ def device_in_use(device, reset_timer=False):
     device.state = 'in-use'
     if reset_timer:
         device.expiration = datetime.now() + timedelta(minutes=30)
+        send_device_state(device, 'update-expiration', expiration=device.expiration.timestamp())
     if datetime.now() < device.expiration:
         delta = device.expiration - datetime.now()
         timer.rm_timer(device.timer)

--- a/HardwareCheckout/device.py
+++ b/HardwareCheckout/device.py
@@ -94,5 +94,12 @@ def device_in_use(device):
 
 def device_provisioning(device):
     device.state = 'provisioning'
+    device.expiration = None
     db.session.add(device)
     db.session.commit()
+
+
+def restart_all_timers():
+    for device in DeviceQueue.query:
+        if device.state in ('ready', 'in-queue'):
+            device_ready(device)

--- a/HardwareCheckout/models.py
+++ b/HardwareCheckout/models.py
@@ -17,7 +17,6 @@ class User(db.Model, UserMixin):
     roles = db.relationship('Role', secondary='user_roles')
     userQueueEntry = relationship("UserQueue")
     deviceQueueEntry = relationship("DeviceQueue", foreign_keys="DeviceQueue.owner")
-    type = Column(Integer, ForeignKey("devicetype.id"))
 
 class Role(db.Model):
     __tablename__ = 'roles'
@@ -44,13 +43,15 @@ class UserQueue(db.Model):
 class DeviceQueue(db.Model):
     __tablename__ = "devicequeue"
     id = Column(Integer, primary_key=True)
+    name = Column(String(200), unique=True)
+    password = Column(String(93), unique=True)
     sshAddr = Column(String(200))
     webUrl = Column(String(200))
     roUrl = Column(String(200))
-    inUse = Column(Boolean)
-    inReadyState = Column(Boolean)
+    state = Column(String(200))
     expiration = Column(DateTime)
+    timer = Column(String(200))
     owner = Column(Integer, ForeignKey("user.id"))
-    device = Column(Integer, ForeignKey("user.id"))
+    type = Column(Integer, ForeignKey("devicetype.id"))
 
     

--- a/HardwareCheckout/models.py
+++ b/HardwareCheckout/models.py
@@ -50,7 +50,6 @@ class DeviceQueue(db.Model):
     roUrl = Column(String(200))
     state = Column(String(200))
     expiration = Column(DateTime)
-    timer = Column(String(200))
     owner = Column(Integer, ForeignKey("user.id"))
     type = Column(Integer, ForeignKey("devicetype.id"))
 

--- a/HardwareCheckout/queue.py
+++ b/HardwareCheckout/queue.py
@@ -1,11 +1,20 @@
 from flask import Blueprint
 from flask_login import current_user, login_required
+from flask_socketio import disconnect, join_room, Namespace
 
 from . import db
 from .device import device_ready
 from .models import DeviceQueue, User, UserQueue
 
 queue = Blueprint('queue', __name__)
+
+
+class QueueNamespace(Namespace):
+    def on_connect(self):
+        if current_user.is_authenticated:
+            join_room('user:%i' % current_user.id)
+        else:
+            disconnect()
 
 
 @queue.route('/<id>', methods=['GET'])

--- a/HardwareCheckout/queue.py
+++ b/HardwareCheckout/queue.py
@@ -1,0 +1,37 @@
+from flask import Blueprint
+from flask_login import current_user, login_required
+
+from . import db
+from .device import device_ready
+from .models import DeviceQueue, User, UserQueue
+
+queue = Blueprint('queue', __name__)
+
+
+@queue.route('/<id>', methods=['GET'])
+def handle_get(id):
+    return {'result': [{'name': name} for name, in db.session.query(User.name).select_from(UserQueue).join(User).filter(UserQueue.type == id).order_by(UserQueue.id)]}
+
+
+@queue.route('/<id>', methods=['POST'])
+@login_required
+def handle_post(id):
+    entry = UserQueue.query.filter_by(userId=current_user.id, type=id).first()
+    if entry:
+        return {'result': 'success'}
+    entry = UserQueue(userId=current_user.id, type=id)
+    db.session.add(entry)
+    db.session.commit()
+    for device in DeviceQueue.query.filter_by(type=id, state='ready'):
+        device_ready(device)
+    return {'result': 'success'}
+
+
+@queue.route('/<id>', methods=['DELETE'])
+@login_required
+def handle_delete(id):
+    entry = UserQueue.query.filter_by(userId=current_user.id, type=id).first()
+    if entry:
+        db.session.delete(entry)
+    db.session.commit()
+    return {'result': 'success'}

--- a/HardwareCheckout/templates/index.html
+++ b/HardwareCheckout/templates/index.html
@@ -47,7 +47,7 @@
         channel: "carhackingvillage3"
     });
 
-    let socket = io();
+    let socket = io("/queue");
     socket.on("json", function(msg) {
         if (msg.message == "device_available") {
             notify("Your device is ready");

--- a/HardwareCheckout/timer.py
+++ b/HardwareCheckout/timer.py
@@ -1,0 +1,38 @@
+import os
+from base64 import urlsafe_b64encode
+
+from flask import Blueprint
+
+
+def Timer(path):
+    timer = Blueprint('timer', __name__)
+    map = {}
+
+    def add_timer(callback, timeout):
+        timeout = int(timeout)
+        key = urlsafe_b64encode(os.urandom(32)).decode('latin-1').rstrip('=')
+        if key in map:
+            raise Exception('random number collision (!)')
+        map[key] = callback
+        if os.system('systemd-run --on-active=%i curl -X POST http://localhost:5000%s/%s' % (timeout, path, key)):
+            del map[key]
+            raise Exception('systemd-run failed')
+        return key
+
+    def rm_timer(key):
+        try:
+            del map[key]
+        except KeyError:
+            pass
+
+    @timer.route('/<key>', methods=['POST'])
+    def handle_timer(key):
+        if key in map:
+            callback = map[key]
+            del map[key]
+            callback()
+        return ''
+
+    timer.add_timer = add_timer
+    timer.rm_timer = rm_timer
+    return timer

--- a/addDevice.py
+++ b/addDevice.py
@@ -30,6 +30,7 @@ s.add(
             args.password, 
             method="pbkdf2:sha256:45000"
         ),
+        state="want-provision",
         type=typeID.id
     )
 )

--- a/addDevice.py
+++ b/addDevice.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 from HardwareCheckout import db, create_app
-from HardwareCheckout.models import User, Role, DeviceType
+from HardwareCheckout.models import DeviceQueue, Role, DeviceType
 from HardwareCheckout.config import db_path
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -24,13 +24,12 @@ if not typeID:
     exit(1)
 
 s.add(
-    User(
+    DeviceQueue(
         name=args.username, 
         password=generate_password_hash(
             args.password, 
             method="pbkdf2:sha256:45000"
         ),
-        roles=[device],
         type=typeID.id
     )
 )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 bcrypt==3.1.7
 blinker==1.4
+certifi==2020.4.5.1
 cffi==1.14.0
+chardet==3.0.4
 click==7.1.1
 cryptography==2.8
 Flask==1.1.1
@@ -10,6 +12,7 @@ Flask-SocketIO==4.2.1
 Flask-SQLAlchemy==2.4.1
 Flask-User==1.0.2.2
 Flask-WTF==0.14.3
+idna==2.9
 itsdangerous==1.1.0
 Jinja2==2.11.1
 MarkupSafe==1.1.1
@@ -17,7 +20,9 @@ passlib==1.7.2
 pycparser==2.20
 python-engineio==3.12.1
 python-socketio==4.5.1
+requests==2.23.0
 six==1.14.0
 SQLAlchemy==1.3.15
+urllib3==1.25.8
 Werkzeug==1.0.0
 WTForms==2.2.1

--- a/tmate/config.ini
+++ b/tmate/config.ini
@@ -2,7 +2,6 @@
 username = device1
 password = randpass1
 data_dir = /tmp/devices/device1
-use_docker = 1
 
 [device2]
 username = device2

--- a/tmate/config.ini
+++ b/tmate/config.ini
@@ -1,0 +1,10 @@
+[device1]
+username = device1
+password = randpass1
+data_dir = /tmp/devices/device1
+use_docker = 1
+
+[device2]
+username = device2
+password = randpass2
+data_dir = /tmp/devices/device2

--- a/tmate/connected.py
+++ b/tmate/connected.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+import sys
+from base64 import b64encode
+from configparser import ConfigParser
+
+import requests
+
+if len(sys.argv) != 2:
+    print('Usage: device.py <profile>', file=sys.stderr)
+    sys.exit(1)
+
+config = ConfigParser()
+config.read('config.ini')
+
+try:
+    config = config[sys.argv[1]]
+except KeyError as e:
+    print('Section {} not found in config.ini'.format(e.args[0]))
+    sys.exit(1)
+
+try:
+    username = config['username']
+    password = config['password']
+except KeyError as e:
+    print('Missing required parameter {} in config.ini'.format(e.args[0]))
+    sys.exit(1)
+
+if ':' in username:
+    print('Colon character (:) is not allowed inside of a username per RFC 7617', file=sys.stderr)
+    sys.exit(1)
+
+r = requests.put('http://localhost:5000/device/state', json={'state': 'client-connected'}, auth=(username, password))
+
+sys.exit(r.status_code != 200)

--- a/tmate/deprovision.sh
+++ b/tmate/deprovision.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+if [ $USE_DOCKER -eq 1 ]
+then
+    docker stop "$DEVICE_NAME"
+    docker rm "$DEVICE_NAME"
+else
+    tmate -S "$TMATE_SOCK" kill-session
+fi

--- a/tmate/device.py
+++ b/tmate/device.py
@@ -1,14 +1,68 @@
 #!/usr/bin/env python3
-import os, sys
+import os, os.path, sys
 from base64 import b64encode
+from configparser import ConfigParser
+from subprocess import Popen
 
 from socketio import Client
 
-username = os.environ['DEVICENAME'].encode('latin1')
-password = os.environ['PASSWORD'].encode('latin1')
-data_dir = os.environ['DEVICE_DIR']
-dirfd = os.open(data_dir, os.O_PATH)
-auth_hdr = {'Authorization': 'Basic ' + b64encode(username + b':' + password).decode('latin1')}
+if len(sys.argv) != 2:
+    print('Usage: device.py <profile>', file=sys.stderr)
+    sys.exit(1)
+
+config = ConfigParser()
+config.read('config.ini')
+
+try:
+    config = config[sys.argv[1]]
+except KeyError as e:
+    print('Section {} not found in config.ini'.format(e.args[0]))
+    sys.exit(1)
+
+try:
+    username = config['username']
+    password = config['password']
+    data_dir = os.path.realpath(config['data_dir'])
+except KeyError as e:
+    print('Missing required parameter {} in config.ini'.format(e.args[0]))
+    sys.exit(1)
+
+if ':' in username:
+    print('Colon character (:) is not allowed inside of a username per RFC 7617', file=sys.stderr)
+    sys.exit(1)
+
+try:
+    uid = config['uid']
+except KeyError:
+    uid = os.getuid()
+
+try:
+    gid = config['gid']
+except KeyError:
+    gid = os.getgid()
+
+try:
+    use_docker = config['use_docker']
+except KeyError:
+    use_docker = 0
+
+install_dir = os.path.abspath(os.path.realpath(sys.argv[0]) + os.path.sep + '..')
+os.makedirs(data_dir, mode=0o700, exist_ok=True)
+
+try:
+    os.chown(data_dir, uid, gid)
+except PermissionError:
+    print('Failed to chown data directory, continuing anyways...')
+
+os.environ['DEVICE_NAME'] = sys.argv[1]
+os.environ['INSTALL_DIR'] = install_dir
+os.environ['DATA_DIR'] = data_dir
+os.environ['TMATE_SOCK'] = os.path.abspath(data_dir + os.path.sep + 'tmate.sock')
+os.environ['CONFIG_FILE'] = os.path.abspath(data_dir + os.path.sep + 'config')
+os.environ['EXPIRATION_TIMESTAMP'] = os.path.abspath(data_dir + os.path.sep + 'expiration-timestamp')
+os.environ['USE_DOCKER'] = str(use_docker)
+
+auth_hdr = {'Authorization': 'Basic ' + b64encode((username + ':' + password).encode()).decode()}
 
 c = Client()
 
@@ -16,11 +70,21 @@ initial_connect = False
 is_provisioned = False
 error = 1
 
+ssh = ''
+web = ''
+web_ro = ''
 
-def openat(*args, **kwargs):
-    def opener(path, flags):
-        return os.open(path, flags, dir_fd=dirfd)
-    return open(*args, opener=opener, **kwargs)
+
+def run_external(args):
+    def preexec():
+        os.setgid(gid)
+        os.setuid(uid)
+        os.chdir(data_dir)
+
+    args[0] = install_dir + os.path.sep + args[0]
+    proc = Popen(args, preexec_fn=preexec)
+    proc.wait()
+    return proc.returncode
 
 
 @c.on('connect', namespace='/device')
@@ -44,27 +108,35 @@ def device_disconnected():
 @c.on('json', namespace='/device')
 def handle_response(data):
     global is_provisioned, error
+    global ssh, web, web_ro
     print('Received data from server: %r' % data)
     if 'state' not in data:
         return
     if data['state'] == 'want-provision':
         print('Server wants a provision')
         if not is_provisioned:
+            with open(os.environ['CONFIG_FILE'], 'w') as f:
+                print('[config]', file=f)
             print('Provisioning...')
-            code = os.system('./provision.sh')
+            code = run_external(['provision.sh'])
             if code:
                 print('ERROR: provision.sh failed with exit code %d' % code, file=sys.stderr)
                 send('provision-failed')
                 return
+            config = ConfigParser()
+            config.read(os.environ['CONFIG_FILE'])
+            ssh = config['config']['ssh']
+            web = config['config']['web']
+            web_ro = config['config']['web_ro']
             is_provisioned = True
         else:
             print('Already provisioned, nothing to do')
-        send('is-provisioned')
+        send('is-provisioned', ssh=ssh, web=web, web_ro=web_ro)
     elif data['state'] == 'want-deprovision':
         print('Server wants a deprovision')
         if is_provisioned:
             print('Deprovisioning...')
-            code = os.system('./deprovision.sh')
+            code = run_external(['deprovision.sh'])
             if code:
                 print('ERROR: deprovision.sh failed with exit code %d' % code, file=sys.stderr)
                 send('deprovision-failed')
@@ -75,14 +147,14 @@ def handle_response(data):
         send('is-deprovisioned')
     elif data['state'] == 'update-expiration':
         print('Updating expiration timestamp')
-        with openat('expiration-timestamp', 'w') as f:
+        with open(os.environ['EXPIRATION_TIMESTAMP'], 'w') as f:
             f.write(str(int(data['expiration'])))
 
 
-def send(state):
-    data = {'state': state}
-    print('Sending %r to server' % data)
-    c.send({'state': state}, namespace='/device')
+def send(state, **kwargs):
+    kwargs['state'] = state
+    print('Sending %r to server' % kwargs)
+    c.send(kwargs, namespace='/device')
 
 
 c.connect('http://localhost:5000', headers=auth_hdr)

--- a/tmate/device.py
+++ b/tmate/device.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import os, sys
+from base64 import b64encode
+
+from socketio import Client
+
+username = os.environ['DEVICENAME'].encode('latin1')
+password = os.environ['PASSWORD'].encode('latin1')
+auth_hdr = {'Authorization': 'Basic ' + b64encode(username + b':' + password).decode('latin1')}
+
+c = Client()
+
+initial_connect = False
+is_provisioned = False
+error = 1
+
+
+@c.on('connect', namespace='/device')
+def device_connected():
+    global initial_connect
+    initial_connect = True
+    print('Device connected to server')
+
+
+@c.on('disconnect', namespace='/device')
+def device_disconnected():
+    if not initial_connect:
+        print('FATAL ERROR: Server rejected connection', file=sys.stderr)
+        print('Verify that the DEVICENAME and PASSWORD environment variables are correct and try again', file=sys.stderr)
+        c.disconnect()
+    else:
+        print('Device disconnected, should reconnect soon')
+        print('If not, try CTRL-c and verify DEVICENAME and PASSWORD environment variables')
+
+
+@c.on('json', namespace='/device')
+def handle_response(data):
+    global is_provisioned, error
+    print('Received data from server: %r' % data)
+    if 'state' not in data or data[state] not in ('want-provision', 'want-deprovision'):
+        return
+    if data[state] == 'want-provision':
+        if not is_provisioned:
+            # provision here
+            code = os.system('./provision.sh')
+            if code:
+                print('ERROR: provision.sh failed with exit code %d' % code, file=sys.stderr)
+                c.send({'state': 'provision-failed'})
+                return
+            is_provisioned = True
+        c.send({'state': 'is-provisioned'}, namespace='/device')
+    elif data[state] == 'want-deprovision':
+        if is_provisioned:
+            code = os.system('./deprovision.sh')
+            if code:
+                print('ERROR: deprovision.sh failed with exit code %d' % code, file=sys.stderr)
+                c.send({'state': 'deprovision-failed'})
+                return
+            is_provisioned = False
+        c.send({'state': 'is-deprovisioned'}, namespace='/device')
+
+
+c.connect('http://localhost:5000', headers=auth_hdr)
+c.wait()
+sys.exit(error)

--- a/tmate/install.sh
+++ b/tmate/install.sh
@@ -6,18 +6,15 @@ fi
 
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 apt-get install -y python3-pip
-pip3 install requests
+pip3 install -r $SCRIPTPATH/requirements.txt
 
-if [ -f $SCRIPTPATH/session.sh.bak ]; then
-    mv $SCRIPTPATH/session.sh.bak $SCRIPTPATH/session.sh
-fi
+sed -i.bak "s|localhost:5000|$1|g" $SCRIPTPATH/device.py
+sed -i.bak "s|localhost:5000|$1|g" $SCRIPTPATH/connected.py
 
-sed -i.bak "s|localhost:5000|$1|g" $SCRIPTPATH/session.sh
+sudo install -m 755 -d /opt/hc-client
+sudo install -m 755 $SCRIPTPATH/{connected.py,deprovision.sh,device.py,provision.sh} /opt/hc-client
+sudo install -m 644 $SCRIPTPATH/{session.target,session@.service} /etc/systemd/system
 
-sudo cp $SCRIPTPATH/{session.sh,session_restart.sh} /usr/local/sbin
-sudo cp $SCRIPTPATH/session.target /etc/systemd/system/
-sudo cp $SCRIPTPATH/session@.service /lib/systemd/system/
-sudo cp $SCRIPTPATH/autologout.sh /etc/profile.d/autologout.sh
 sudo systemctl daemon-reload
 sudo systemctl start session.target
 sudo systemctl enable session.target

--- a/tmate/provision.sh
+++ b/tmate/provision.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+set -e
+set -x
+
+cat > "$DATA_DIR/time-remaining.sh" <<EOF
+#!/bin/bash
+
+expiration_time="\`cat $EXPIRATION_TIMESTAMP\`"
+current_time="\`date +%s\`"
+
+time_remaining="\$((expiration_time - current_time))"
+
+if [ "\$time_remaining" -gt 0 ]
+then
+        seconds="\`printf %02d \$((time_remaining % 60))\`"
+        minutes="\`printf %02d \$((time_remaining / 60))\`"
+        echo "Time remaining: \$minutes:\$seconds"
+else
+        echo "Time remaining: 00:00"
+fi
+EOF
+
+chmod a+x "$DATA_DIR/time-remaining.sh"
+
+if [ "$USE_DOCKER" -eq 1 ]
+then
+    docker run -it -d --name="$DEVICE_NAME" \
+           -v "$DATA_DIR:$DATA_DIR" \
+           -v "$INSTALL_DIR/connected.py:$INSTALL_DIR/connected.py" \
+           device_template bash
+    ext() {
+        docker exec "$DEVICE_NAME" "$@"
+    }
+else
+    ext() {
+        "$@"
+    }
+fi
+
+ext tmate -S "$TMATE_SOCK" new-session -d
+ext tmate -S "$TMATE_SOCK" wait tmate-ready
+ext tmate -S "$TMATE_SOCK" set-hook -g mate-joined "run-shell \"$INSTALL_DIR/connected.py $DEVICE_NAME\""
+ext tmate -S "$TMATE_SOCK" set -g status-right "#($DATA_DIR/time-remaining.sh)"
+ext tmate -S "$TMATE_SOCK" set -g status-interval 1
+SSH=$(ext tmate -S "$TMATE_SOCK" display -p "#{tmate_ssh}")
+WEB=$(ext tmate -S "$TMATE_SOCK" display -p "#{tmate_web}")
+WEB_RO=$(ext tmate -S "$TMATE_SOCK" display -p "#{tmate_web_ro}")
+
+echo "ssh = $SSH" >> "$CONFIG_FILE"
+echo "web = $WEB" >> "$CONFIG_FILE"
+echo "web_ro = $WEB_RO" >> "$CONFIG_FILE"

--- a/tmate/requirements.txt
+++ b/tmate/requirements.txt
@@ -1,1 +1,9 @@
+certifi==2020.4.5.1
+chardet==3.0.4
+idna==2.9
+python-engineio==3.12.1
 python-socketio==4.5.1
+requests==2.23.0
+six==1.14.0
+urllib3==1.25.8
+websocket-client==0.57.0

--- a/tmate/requirements.txt
+++ b/tmate/requirements.txt
@@ -1,0 +1,1 @@
+python-socketio==4.5.1

--- a/tmate/session.target
+++ b/tmate/session.target
@@ -1,6 +1,6 @@
 [Unit]
 Description=Session creation target
-Requires=session@1.service session@2.service session@3.service session@4.service session@5.service session@6.service 
+Requires=session@device1.service session@device2.service session@device3.service session@device4.service session@device5.service session@device6.service
 
 [Install]
 WantedBy=multi-user.target

--- a/tmate/session@.service
+++ b/tmate/session@.service
@@ -4,10 +4,9 @@ PartOf=workers.target
 
 [Service]
 User=villager
-Type=forking
-ExecStart=/usr/local/sbin/session.sh %i
+Type=simple
+ExecStart=/usr/bin/env python3 /opt/hc-client/device.py %i
 Restart=on-failure
-ExecReload=/usr/local/sbin/session_restart.sh %i
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There is a lot here

- New APIs for device and queue
- Timers (based on systemd-run and curl, can be changed/improved if needed)
- SocketIO support
  - Users with a logged-in browser session are notified when
    - they're in the front of the queue
    - they've timed out of the queue
    - their device session has ended
  - New device client with SocketIO support is notified when
    - a device must be provisioned
    - a device must be deprovisioned
    - the expiration timer is changed

Everything has been tested fairly well